### PR TITLE
Abstract out host and ports to easily be overridden.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
         <version.org.wildfly.checkstyle>1.0.4.Final</version.org.wildfly.checkstyle>
 
         <openssl.path></openssl.path>
+
+        <!-- Test properties -->
+        <org.wildfly.openssl.test.host>localhost</org.wildfly.openssl.test.host>
+        <org.wildfly.openssl.test.port>7676</org.wildfly.openssl.test.port>
     </properties>
 
     <dependencies>
@@ -100,6 +104,8 @@
                         <javax.net.ssl.trustStore>src/test/resources/client.truststore</javax.net.ssl.trustStore>
                         <javax.net.ssl.keyStorePassword>password</javax.net.ssl.keyStorePassword>
                         <org.wildfly.openssl.path>${openssl.path}</org.wildfly.openssl.path>
+                        <org.wildfly.openssl.test.host>${org.wildfly.openssl.test.host}</org.wildfly.openssl.test.host>
+                        <org.wildfly.openssl.test.port>${org.wildfly.openssl.test.port}</org.wildfly.openssl.test.port>
                     </systemProperties>
                     <argLine>-Djava.library.path=${project.basedir}/libwfssl</argLine>
                 </configuration>

--- a/src/test/java/org/wildfly/openssl/ALPNTest.java
+++ b/src/test/java/org/wildfly/openssl/ALPNTest.java
@@ -18,7 +18,6 @@
 package org.wildfly.openssl;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
@@ -43,7 +42,7 @@ public class ALPNTest {
 
     @Test
     public void testALPN() throws IOException, NoSuchAlgorithmException {
-        try (ServerSocket serverSocket = new ServerSocket(7676)) {
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
             final AtomicReference<byte[]> sessionID = new AtomicReference<>();
             final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLSv1");
             final AtomicReference<OpenSSLEngine> engineAtomicReference = new AtomicReference<>();
@@ -56,7 +55,7 @@ public class ALPNTest {
             acceptThread.start();
             final OpenSSLSocket socket = (OpenSSLSocket) sslContext.getSocketFactory().createSocket();
             socket.setApplicationProtocols("h2/13", "h2", "http");
-            socket.connect(new InetSocketAddress("localhost", 7676));
+            socket.connect(SSLTestUtils.createSocketAddress());
             socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
             byte[] data = new byte[100];
             int read = socket.getInputStream().read(data);
@@ -70,7 +69,7 @@ public class ALPNTest {
 
     @Test
     public void testALPNFailure() throws IOException, NoSuchAlgorithmException {
-        try (ServerSocket serverSocket = new ServerSocket(7676)) {
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
             final AtomicReference<byte[]> sessionID = new AtomicReference<>();
             final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLSv1");
             final AtomicReference<OpenSSLEngine> engineAtomicReference = new AtomicReference<>();
@@ -82,7 +81,7 @@ public class ALPNTest {
             })));
             acceptThread.start();
             final OpenSSLSocket socket = (OpenSSLSocket) sslContext.getSocketFactory().createSocket();
-            socket.connect(new InetSocketAddress("localhost", 7676));
+            socket.connect(SSLTestUtils.createSocketAddress());
             socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
             byte[] data = new byte[100];
             int read = socket.getInputStream().read(data);

--- a/src/test/java/org/wildfly/openssl/BasicOpenSSLEngineTest.java
+++ b/src/test/java/org/wildfly/openssl/BasicOpenSSLEngineTest.java
@@ -18,7 +18,6 @@
 package org.wildfly.openssl;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
@@ -45,14 +44,14 @@ public class BasicOpenSSLEngineTest {
 
     @Test
     public void basicOpenSSLTest() throws IOException, NoSuchAlgorithmException {
-        try (ServerSocket serverSocket = new ServerSocket(7676)) {
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
             final AtomicReference<byte[]> sessionID = new AtomicReference<>();
             final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLSv1");
 
             Thread acceptThread = new Thread(new EchoRunnable(serverSocket, sslContext, sessionID));
             acceptThread.start();
             final SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
-            socket.connect(new InetSocketAddress("localhost", 7676));
+            socket.connect(SSLTestUtils.createSocketAddress());
             socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
             byte[] data = new byte[100];
             int read = socket.getInputStream().read(data);
@@ -65,7 +64,7 @@ public class BasicOpenSSLEngineTest {
 
     @Test
     public void openSslLotsOfDataTest() throws IOException, NoSuchAlgorithmException {
-        try (ServerSocket serverSocket = new ServerSocket(7676)) {
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
             final AtomicReference<byte[]> sessionID = new AtomicReference<>();
             final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLSv1");
 
@@ -73,7 +72,7 @@ public class BasicOpenSSLEngineTest {
             Thread acceptThread = new Thread(target);
             acceptThread.start();
             final SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
-            socket.connect(new InetSocketAddress("localhost", 7676));
+            socket.connect(SSLTestUtils.createSocketAddress());
             String message = generateMessage(1000);
             socket.getOutputStream().write(message.getBytes(StandardCharsets.US_ASCII));
             socket.getOutputStream().write(new byte[]{0});

--- a/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketTest.java
+++ b/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketTest.java
@@ -18,7 +18,6 @@
 package org.wildfly.openssl;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
@@ -37,7 +36,7 @@ public class BasicOpenSSLSocketTest {
     @Test
     public void basicOpenSSLTest() throws IOException, NoSuchAlgorithmException {
 
-        try (ServerSocket serverSocket = new ServerSocket(7676)) {
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
             OpenSSLProvider.register();
             final AtomicReference<byte[]> sessionID = new AtomicReference<>();
 
@@ -45,7 +44,7 @@ public class BasicOpenSSLSocketTest {
             acceptThread.start();
             final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLSv1");
             final SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
-            socket.connect(new InetSocketAddress("localhost", 7676));
+            socket.connect(SSLTestUtils.createSocketAddress());
             socket.getOutputStream().write("hello world".getBytes(StandardCharsets.US_ASCII));
             byte[] data = new byte[100];
             int read = socket.getInputStream().read(data);

--- a/src/test/java/org/wildfly/openssl/SSLTestUtils.java
+++ b/src/test/java/org/wildfly/openssl/SSLTestUtils.java
@@ -20,6 +20,9 @@ package org.wildfly.openssl;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.SocketAddress;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -36,6 +39,9 @@ import javax.net.ssl.TrustManagerFactory;
  * @author Stuart Douglas
  */
 public class SSLTestUtils {
+
+    public static final String HOST = System.getProperty("org.wildfly.openssl.test.host", "localhost");
+    public static final int PORT = Integer.parseInt(System.getProperty("org.wildfly.openssl.test.port", "7676"));
 
     private static KeyStore loadKeyStore(final String name) throws IOException {
         final InputStream stream = BasicOpenSSLEngineTest.class.getClassLoader().getResourceAsStream(name);
@@ -88,6 +94,14 @@ public class SSLTestUtils {
             out.write(buf, 0, r);
         }
         return out.toByteArray();
+    }
+
+    public static ServerSocket createServerSocket() throws IOException {
+        return new ServerSocket(PORT);
+    }
+
+    public static SocketAddress createSocketAddress() {
+        return new InetSocketAddress(HOST, PORT);
     }
 
 }

--- a/src/test/java/org/wildfly/openssl/SslCiphersTest.java
+++ b/src/test/java/org/wildfly/openssl/SslCiphersTest.java
@@ -18,7 +18,6 @@
 package org.wildfly.openssl;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
@@ -77,7 +76,7 @@ public class SslCiphersTest {
 
             final AtomicReference<SSLEngine> engineRef = new AtomicReference<>();
 
-            ServerSocket serverSocket = new ServerSocket(7676);
+            ServerSocket serverSocket = SSLTestUtils.createServerSocket();
             EchoRunnable echo = new EchoRunnable(serverSocket, sslContext, sessionID, (engine -> {
                 engineRef.set(engine);
                 try {
@@ -92,7 +91,7 @@ public class SslCiphersTest {
 
             final SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
             socket.setEnabledCipherSuites(new String[]{suite});
-            socket.connect(new InetSocketAddress("localhost", 7676));
+            socket.connect(SSLTestUtils.createSocketAddress());
             socket.getOutputStream().write("hello world".getBytes(StandardCharsets.US_ASCII));
             byte[] data = new byte[100];
             int read = socket.getInputStream().read(data);


### PR DESCRIPTION
Just a minor, not required, test change to allow ports and the binding host name to be easily overridden. This may be useful once this is used in a CI environment.
